### PR TITLE
Introduce the queue-eval-loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Unreleased
 
-## Added
-
-## Fixed
-
 ## Changed
+
+- Instead of using the ClojureScript PREPL we now use a queue based solution
+  that bypasses the need for a Reader. This should hopefully lead to better
+  reliability.
 
 # 0.0-32 (2019-04-23 / 3d46a25)
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To see all messages coming in over the PREPL and Websocket you can set
 <!-- license-epl -->
 ## License
 
-Copyright &copy; 2018 Arne Brasseur
+Copyright &copy; 2019 Arne Brasseur
 
 Available under the terms of the Eclipse Public License 1.0, see LICENSE.txt
 <!-- /license-epl -->

--- a/src/kaocha/cljs/prepl.clj
+++ b/src/kaocha/cljs/prepl.clj
@@ -1,76 +1,22 @@
 (ns kaocha.cljs.prepl
-  (:require [cljs.core.server :as cljs-server]
+  (:require [kaocha.cljs.queue-eval-loop :as qel]
             [clojure.java.io :as io]
             [clojure.tools.reader.reader-types :as ctr.types])
   (:import [java.util.concurrent BlockingQueue LinkedBlockingQueue]))
 
-(defprotocol Writable
-  (write [writer string]))
-
-(deftype WritableReader [^java.util.Queue queue
-                         ^:unsynchronized-mutable ^String s
-                         ^:unsynchronized-mutable ^long s-pos]
-  Writable
-  (write [this string]
-    (.put queue string))
-
-  ctr.types/Reader
-  (read-char [this]
-    (cond
-      (= :done s)
-      nil
-
-      (or (nil? s) (>= s-pos (count s)))
-      (do
-        (set! s (.take queue))
-        (set! s-pos 0)
-        (when-not (= :done s)
-          (ctr.types/read-char this)))
-
-      (> (count s) s-pos)
-      (let [r (nth s s-pos)]
-        (set! s-pos (inc s-pos))
-        r)))
-
-  (peek-char [this]
-    (cond
-      (= :done s)
-      nil
-
-      (or (nil? s) (>= s-pos (count s)))
-      (do
-        (set! s (.take queue))
-        (set! s-pos 0)
-        (when-not (= :done s)
-          (ctr.types/peek-char this)))
-
-      (> (count s) s-pos)
-      (nth s s-pos))))
-
-(defn writable-reader []
-  (let [queue (LinkedBlockingQueue.)
-        reader (->WritableReader queue nil 0)]
-    reader))
-
 (defn prepl [repl-env ^BlockingQueue queue]
-  (let [writable-reader  (writable-reader)
-        push-back-reader (ctr.types/push-back-reader writable-reader)
-        eval             (fn [s]
-                           #_(println s)
-                           (write writable-reader (str s "\n")))
-        opts             {}
-        reader           (ctr.types/source-logging-push-back-reader push-back-reader)
-        out-fn           #(.offer queue (let [tag (:tag %)]
-                                          (assoc (dissoc % :tag) :type (keyword "cljs" (name tag)))))]
+  (let [eval-queue (LinkedBlockingQueue.)
+        eval       (fn [form] (.add eval-queue form))
+        opts       {}
+        out-fn     #(.add queue (let [tag (:tag %)]
+                                  (assoc (dissoc % :tag) :type (keyword "cljs" (name tag)))))]
     (future
       (try
-        (cljs-server/prepl repl-env opts reader out-fn)
-        (.offer (.-queue writable-reader) :done)
-        (.offer queue {:type ::exit})
+        (qel/start! repl-env opts eval-queue out-fn)
+        (.add queue {:type ::exit})
         (catch Exception e
-          (.offer (.-queue writable-reader) :done)
-          (.offer queue {:type ::exit})
-          (println "Exception in prepl" e))))
+          (.add queue {:type ::exit})
+          (println "Exception in queue-eval-loop" e))))
     eval))
 
 (comment
@@ -81,21 +27,16 @@
     (def eval-cljs eval)
     (def res-chan chan))
 
-  (eval-cljs "(require 'kaocha.cljs.websocket-client :reload)")
-  (eval-cljs "kaocha.cljs.websocket-client/socket")
-  (eval-cljs "(kaocha.cljs.websocket-client/connect!)")
-  (eval-cljs "(require 'ktest.first-test)")
-  (eval-cljs "(ktest.first-test/regular-fail)")
+  (eval-cljs '(require 'kaocha.cljs.websocket-client :reload))
+  (eval-cljs 'kaocha.cljs.websocket-client/socket)
+  (eval-cljs '(kaocha.cljs.websocket-client/connect!))
+  (eval-cljs '(require 'ktest.first-test))
+  (eval-cljs '(ktest.first-test/regular-fail))
 
-  (eval-cljs ":cljs/quit")
+  (eval-cljs ':cljs/quit)
 
-  (eval-cljs "(xxx)")
-
-  (io/resource "ktest/first_test.cljs")
-  (.getContextClassLoader (Thread/currentThread))
-  (io/resource "ktest/first_test.cljs"), :cljc ktest/first_test.cljc
-
-  (eval-cljs "(require 'kaocha.cljs.websocket-client) (kaocha.cljs.websocket-client/connect!) :done")
+  (eval-cljs '(xxx))
+  (eval-cljs '(+ 1 1))
 
   (take-while identity (repeatedly #(.poll res-chan)))
 

--- a/src/kaocha/cljs/queue_eval_loop.clj
+++ b/src/kaocha/cljs/queue_eval_loop.clj
@@ -1,0 +1,100 @@
+(ns kaocha.cljs.queue-eval-loop
+  (:refer-clojure :exclude [with-bindings resolve-fn prepl io-prepl])
+  (:require [cljs.env :as env]
+            [cljs.closure :as closure]
+            [cljs.analyzer :as ana]
+            [cljs.analyzer.api :as ana-api]
+            [cljs.repl :as repl]
+            [cljs.compiler :as comp]
+            [cljs.tagged-literals :as tags]))
+
+(defprotocol Input
+  (take! [this]))
+
+(extend-protocol Input
+  java.util.Queue
+  (take! [q] (.take q))
+
+  ;; clojure.core.async.impl.channels.ManyToManyChanne
+  ;; (take! [q] (<! q))
+  )
+
+(defmacro with-bindings [& body]
+  `(binding [ana/*cljs-ns* ana/*cljs-ns*
+             ana/*unchecked-if* ana/*unchecked-if*
+             ana/*unchecked-arrays* ana/*unchecked-arrays*]
+     ~@body))
+
+(defn- resolve-fn [valf]
+  (if (symbol? valf)
+    (or (resolve valf)
+        (when-let [nsname (namespace valf)]
+          (require (symbol nsname))
+          (resolve valf))
+        (throw (Exception. (str "can't resolve: " valf))))
+    valf))
+
+(defn repl-quit? [v]
+  (#{":repl/quit" ":cljs/quit"} v))
+
+(defn start!
+  "Like a prepl, but takes a queue which delivers forms, rather than a reader."
+  [repl-env {:keys [special-fns] :as opts} in out-fn & {:keys [stdin]}]
+  (let [repl-opts      (repl/repl-options repl-env)
+        opts           (merge
+                        {:def-emits-var true}
+                        (closure/add-implicit-options
+                         (merge-with (fn [a b] (if (nil? b) a b))
+                           repl-opts opts)))
+        tapfn          #(out-fn {:tag :tap :val %1})
+        env            (ana-api/empty-env)
+        special-fns    (merge repl/default-special-fns special-fns)
+        is-special-fn? (set (keys special-fns))]
+    (env/ensure
+     (repl/maybe-install-npm-deps opts)
+     (comp/with-core-cljs opts
+       (fn []
+         (with-bindings
+           (binding [*in*            (or stdin *in*)
+                     *out*           (PrintWriter-on #(out-fn {:tag :out :val %1}) nil)
+                     *err*           (PrintWriter-on #(out-fn {:tag :err :val %1}) nil)
+                     repl/*repl-env* repl-env]
+             (let [opts (merge opts (:merge-opts (repl/setup repl-env opts)))]
+               (binding [repl/*repl-opts* opts]
+                 (repl/evaluate-form repl-env env "<cljs repl>"
+                                     (with-meta `(~'ns ~'cljs.user) {:line 1 :column 1}) identity opts)
+                 (try
+                   (add-tap tapfn)
+                   (loop []
+                     (when (try
+                             (let [form (take! in)
+                                   s    (pr-str form)]
+                               (try
+                                 (let [start (System/nanoTime)
+                                       ret   (if (and (seq? form) (is-special-fn? (first form)))
+                                               (do
+                                                 ((get special-fns (first form)) repl-env env form opts)
+                                                 "nil")
+                                               (repl/eval-cljs repl-env env form opts))
+                                       ms    (quot (- (System/nanoTime) start) 1000000)]
+                                   (when-not (repl-quit? ret)
+                                     (out-fn {:tag  :ret
+                                              :val  (if (instance? Throwable ret)
+                                                      (Throwable->map ret)
+                                                      ret)
+                                              :ns   (name ana/*cljs-ns*)
+                                              :ms   ms
+                                              :form s})
+                                     true))
+                                 (catch Throwable ex
+                                   (out-fn {:tag :ret                 :val  (Throwable->map ex)
+                                            :ns  (name ana/*cljs-ns*) :form s})
+                                   true)))
+                             (catch Throwable ex
+                               (out-fn {:tag :ret :val (Throwable->map ex)
+                                        :ns  (name ana/*cljs-ns*)})
+                               true))
+                       (recur)))
+                   (finally
+                     (remove-tap tapfn)
+                     (repl/tear-down repl-env))))))))))))

--- a/src/kaocha/cljs/websocket_server.clj
+++ b/src/kaocha/cljs/websocket_server.clj
@@ -21,9 +21,9 @@
       (.put queue {:type ::connect :client con})
       (ws/on-receive con (fn [msg]
                            (let [msg (from-transit msg)]
-                             (.offer queue {:type ::message :client con :message msg}))))
+                             (.add queue {:type ::message :client con :message msg}))))
       (ws/on-close con (fn [status]
-                         (.offer queue {:type ::disconnect :client con}))))))
+                         (.add queue {:type ::disconnect :client con}))))))
 
 (defn send! [client message]
   (ws/send! client (to-transit message) false))


### PR DESCRIPTION
We were jumping through quite some hoops to be able to use the ClojureScript
PREPL programmitcally (oh the irony) because it expects a Reader for its input,
which isn't that convenient when eval'ing forms that are coming from code,
rather than from some character stream.

Instead replaced the prepl with a "queue-eval-loop", which does a queue/take!
rather than a read+string. Seems to work well enough so far, let's hope it helps
with reliability.