### PR TITLE
Pass compiler-options all the way through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   that bypasses the need for a Reader. This should hopefully lead to better
   reliability.
 
+## Fixed
+
+- Correctly pass custom compiler-options to the prepl
+
 # 0.0-32 (2019-04-23 / 3d46a25)
 
 ## Fixed

--- a/src/kaocha/cljs/prepl.clj
+++ b/src/kaocha/cljs/prepl.clj
@@ -4,15 +4,14 @@
             [clojure.tools.reader.reader-types :as ctr.types])
   (:import [java.util.concurrent BlockingQueue LinkedBlockingQueue]))
 
-(defn prepl [repl-env ^BlockingQueue queue]
+(defn prepl [repl-env compiler-opts ^BlockingQueue queue]
   (let [eval-queue (LinkedBlockingQueue.)
         eval       (fn [form] (.add eval-queue form))
-        opts       {}
         out-fn     #(.add queue (let [tag (:tag %)]
                                   (assoc (dissoc % :tag) :type (keyword "cljs" (name tag)))))]
     (future
       (try
-        (qel/start! repl-env opts eval-queue out-fn)
+        (qel/start! repl-env compiler-opts eval-queue out-fn)
         (.add queue {:type ::exit})
         (catch Exception e
           (.add queue {:type ::exit})


### PR DESCRIPTION
This one's a little embarrassing. We first create a `repl-env`, and pass the compiler options there, and then use that `repl-env` to create a `prepl` (actually a `qepl` but who's keeping track). My assumption was that the compiler options would be part of the `repl-options`, and that the `options` option to the prepl were prepl-specific options, but it seems actually both are merged and used as compiler options.

It's not clear to me if this is the correct way to use the `options` argument of the prepl, since it also contains things like `:special-fns`, but it does get the options to where they need to be.

Closes #16