### PR TITLE
Compatibility with Figwheel REPL, WIP

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,6 +11,7 @@
   pjstadig/humane-test-output {:mvn/version "0.9.0"}
 
   lambdaisland/kaocha        {:mvn/version "0.0-418"}
+  lambdaisland/glogi         {:mvn/version "RELEASE"}
   net.ladenthin/streambuffer {:mvn/version "1.1.0"}}
 
  :paths ["src" "resources" "test/cljs"]

--- a/src/kaocha/cljs/websocket.cljs
+++ b/src/kaocha/cljs/websocket.cljs
@@ -1,0 +1,101 @@
+(ns kaocha.cljs.websocket
+  "Cross-platform websocket wrapper, borrowed from Figwheel.
+
+  Relies on goog.net.WebSocket (https://google.github.io/closure-library/api/goog.net.WebSocket.html)"
+  (:require [goog.object :as gobj]
+            [goog.storage.mechanism.mechanismfactory :as storage-factory]
+            [goog.Uri :as guri]
+            [goog.string :as gstring]
+            [goog.net.jsloader :as loader]
+            [goog.net.XhrIo :as xhrio]
+            [goog.log :as glog]
+            [goog.array :as garray]
+            [goog.json :as gjson]
+            [goog.html.legacyconversions :as conv]
+            [goog.userAgent.product :as product])
+  (:import [goog.net WebSocket]
+           [goog.debug Console]
+           [goog.Uri QueryData]
+           [goog Promise]
+           [goog.storage.mechanism HTML5SessionStorage]))
+
+(def host-env
+  (cond
+    (not (nil? goog/nodeGlobalRequire)) :node
+    (not (nil? goog/global.document)) :html
+    (and (exists? goog/global.navigator)
+         (= goog/global.navigator.product "ReactNative"))
+    :react-native
+    (and
+     (nil? goog/global.document)
+     (exists? js/self)
+     (exists? (.-importScripts js/self)))
+    :worker))
+
+(def event-types
+  {;; OPENED Fired when the WebSocket connection has been established.
+   :open  goog.net.WebSocket.EventType.OPENED
+   ;; CLOSED Fired when an attempt to open the WebSocket fails or there is a connection failure after a successful connection has been established.
+   :close  goog.net.WebSocket.EventType.CLOSED
+   ;; ERROR Fired when the WebSocket encounters an error.
+   :error   goog.net.WebSocket.EventType.ERROR
+   ;; MESSAGE Fired when a new message arrives from the WebSocket.
+   :message goog.net.WebSocket.EventType.MESSAGE})
+
+(defn get-websocket-class []
+  (or
+   (gobj/get goog.global "WebSocket")
+   (gobj/get goog.global "FIGWHEEL_WEBSOCKET_CLASS")
+   (and (= host-env :node)
+        (try (js/require "ws")
+             (catch js/Error e
+               nil)))
+   (and (= host-env :worker)
+        (gobj/get js/self "WebSocket"))))
+
+(defn ensure-websocket [thunk]
+  (if (gobj/get goog.global "WebSocket")
+    (thunk)
+    (when-let [websocket-class (get-websocket-class)]
+      (do
+        (gobj/set goog.global "WebSocket" websocket-class)
+        (let [result (thunk)]
+          (gobj/set goog.global "WebSocket" nil)
+          result)))))
+
+(defn make-websocket ^goog.net.WebSocket []
+  (ensure-websocket #(goog.net.WebSocket.)))
+
+(defn register-handlers* [^goog.net.WebSocket ws handler-map]
+  (doseq [[type handler-fn] handler-map]
+    ;; TODO addEventListener is deprecated, can we swap for (.listen ...)
+    (assert (get event-types type) type)
+    (.addEventListener ws (get event-types type) handler-fn)))
+
+(defn register-handlers [^goog.net.WebSocket ws handler-map]
+  (ensure-websocket #(register-handlers* ws handler-map)))
+
+(defn open!* [^goog.net.WebSocket ws url]
+  (.open ws url))
+
+(defn open! [^goog.net.WebSocket ws url]
+  (ensure-websocket #(open! ws url)))
+
+(defn connect! [url handler-map]
+  (ensure-websocket
+   #(let [ws (goog.net.WebSocket.)]
+      (register-handlers* ws handler-map)
+      (open!* ws url)
+      ws)))
+
+(defn send! [^goog.net.WebSocket ws msg]
+  (ensure-websocket #(.send ws msg)))
+
+(defn open? [^goog.net.WebSocket ws]
+  (ensure-websocket #(.isOpen ws)))
+
+(defn close! [^goog.net.WebSocket ws]
+  (.close ws))
+
+(defn message-data [event]
+  (gobj/get event "message"))

--- a/src/kaocha/type/cljs.clj
+++ b/src/kaocha/type/cljs.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [symbol])
   (:require [cljs.analyzer :as ana]
             [cljs.compiler :as comp]
+            [cljs.build.api]
             [cljs.env :as env]
             [cljs.repl :as repl]
             cljs.repl.server
@@ -69,14 +70,15 @@
                                 (ns-testable ns-sym ns-file))))
                           test-files)]
     (assoc testable
-      :cljs/compiler-options options
-      :cljs/repl-env repl-env
-      :cljs/timeout timeout
-      :kaocha.test-plan/tests
-      (env/with-compiler-env cenv
-        (comp/with-core-cljs {}
-          (fn []
-            (testable/load-testables testables)))))))
+           :cljs/compiler-options options
+           :cljs/repl-env repl-env
+           :cljs/timeout timeout
+           :kaocha.test-plan/tests
+           (env/with-compiler-env cenv
+             (cljs.build.api/build "src" options)
+             (comp/with-core-cljs {}
+               (fn []
+                 (testable/load-testables testables)))))))
 
 (defmethod testable/-load ::ns [testable]
   (let [ns-name (::ns testable)


### PR DESCRIPTION
This needs cleaning up, but at least it seems to be working. See https://github.com/lambdaisland/kaocha-demo/blob/figwheel-repl/tests.edn#L8-L14 for an example of how to use it.

This adds a precompilation step (necessary for figwheel-repl, but this will become configurable), and switches the websocket to use `goog.net.WebSocket`, same as Figwheel itself, plus it borrows Figwheel's host checking to find a suitable WS implementation.

ping @mk @kommen