### PR TITLE
Matcher combinators compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+- Added support for matcher-combinators
+
 ## Fixed
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changed
 
+- When using the nodejs repl type, automatically set the CLJS compile target to :nodejs
+
 # 0.0-51 (2019-09-11 / 4b6a751)
 
 ## Added

--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,7 @@
 
   pjstadig/humane-test-output {:mvn/version "0.9.0"}
 
-  lambdaisland/kaocha        {:mvn/version "0.0-418"}
+  lambdaisland/kaocha        {:mvn/version "0.0-541"}
   lambdaisland/glogi         {:mvn/version "RELEASE"}
   net.ladenthin/streambuffer {:mvn/version "1.1.0"}}
 

--- a/src/kaocha/cljs/hierarchy.clj
+++ b/src/kaocha/cljs/hierarchy.clj
@@ -1,0 +1,5 @@
+(ns kaocha.cljs.hierarchy
+  (:require [kaocha.hierarchy :as hierarchy]))
+
+(defmacro known-keys []
+  (get-in hierarchy/hierarchy [:descendants :kaocha/known-key]))

--- a/src/kaocha/type/cljs.clj
+++ b/src/kaocha/type/cljs.clj
@@ -56,12 +56,14 @@
   (ctn.parse/name-from-ns-decl (ctn.file/read-file-ns-decl f)))
 
 (defmethod testable/-load :kaocha.type/cljs [testable]
-  (let [copts        (cond-> (:cljs/compiler-options testable {})
+  (let [repl-env     (:cljs/repl-env testable 'cljs.repl.node/repl-env)
+        copts        (cond-> (:cljs/compiler-options testable {})
                        *debug*
                        (update :closure-defines assoc
                                `log-level "DEBUG"
-                               `root-log-level "DEBUG"))
-        repl-env     (:cljs/repl-env testable 'cljs.repl.node/repl-env)
+                               `root-log-level "DEBUG")
+                       (= 'cljs.repl.node/repl-env repl-env)
+                       (assoc :target :nodejs))
         timeout      (:cljs/timeout testable 15000)
         source-paths (map io/file (:kaocha/source-paths testable))
         test-paths   (map io/file (:kaocha/test-paths testable))

--- a/src/kaocha/type/cljs.clj
+++ b/src/kaocha/type/cljs.clj
@@ -33,7 +33,6 @@
 (def ^:dynamic *debug* false)
 
 (require 'kaocha.cljs.print-handlers)
-(require 'kaocha.type.var) ;; load the hierarchy for :kaocha.type.var/zero-assertions
 
 (defn ns-testable [ns-sym ns-file]
   {::testable/type ::ns
@@ -240,6 +239,9 @@
                    eval)
             limited-testable (select-keys testable [:kaocha.testable/id :cljs/repl-env :cljs/compiler-options])]
         (try
+          (when (io/resource "matcher_combinators/model.cljc")
+            (eval '(require 'matcher-combinators.model)))
+
           (eval '(require 'kaocha.cljs.websocket-client
                           'kaocha.cljs.run))
           (eval done)

--- a/src/kaocha/type/cljs.clj
+++ b/src/kaocha/type/cljs.clj
@@ -32,7 +32,8 @@
 ;; Set in tests.edn with {:bindings {kaocha.type.cljs/*debug* true}}
 (def ^:dynamic *debug* false)
 
-(require 'kaocha.cljs.print-handlers)
+(require 'kaocha.cljs.print-handlers
+         'kaocha.type.var) ;; (defmethod report/fail-summary ::zero-assertions)
 
 (defn ns-testable [ns-sym ns-file]
   {::testable/type ::ns

--- a/test/step_definitions/kaocha_integration.clj
+++ b/test/step_definitions/kaocha_integration.clj
@@ -87,7 +87,7 @@
     (binding [*out* deps-out]
       (with-print-namespace-maps false
         (clojure.pprint/pprint {:paths ["src" "test"]
-                                :deps {'org.clojure/clojure           {:mvn/version "1.10.0-RC5"}
+                                :deps {'org.clojure/clojure           {:mvn/version "RELEASE"}
                                        'lambdaisland/kaocha-cljs      {:local/root (project-dir-path)}
                                        'lambdaisland/kaocha-cloverage {:mvn/version "RELEASE"}}})))))
 


### PR DESCRIPTION
 Add support for Matcher Combinators

This relies on the latest Kaocha for an updated message type
hierarchy (:kaocha/known-key) which includes the MC specific messages.

This captures the MC specific events, and serializes their message to the
frontend, maintaining record types.

See also https://github.com/nubank/matcher-combinators/issues/83#issuecomment-530370989