### PR TITLE
Problem: Websocket port is hard-coded

### DIFF
--- a/src/kaocha/cljs/websocket_client.cljs
+++ b/src/kaocha/cljs/websocket_client.cljs
@@ -128,9 +128,9 @@
 
 (t/update-current-env! [:reporter] (constantly :kaocha.type/cljs))
 
-(defn connect! []
+(defn connect! [port]
   (set! socket
-        (ws/connect! "ws://localhost:9753/"
+        (ws/connect! (str "ws://localhost:" port "/")
                      {:open
                       (fn [e]
                         (glogi/info :websocket {:callback :onopen :event e})
@@ -156,5 +156,3 @@
   (when socket
     (glogi/info :msg "Disconnecting websocket")
     (ws/close! socket)))
-
-(kaocha.cljs.websocket-client/connect!)

--- a/src/kaocha/cljs/websocket_server.clj
+++ b/src/kaocha/cljs/websocket_server.clj
@@ -50,4 +50,4 @@
   (ws/send! client (to-transit message) false))
 
 (defn start! [queue]
-  (ws/run-server (ws-handler queue) {:port 9753 :join? false}))
+  (ws/run-server (ws-handler queue) {:port 0 :join? false}))

--- a/src/kaocha/type/cljs.clj
+++ b/src/kaocha/type/cljs.clj
@@ -231,7 +231,8 @@
   (let [queue    (LinkedBlockingQueue.)
         renv     (do (require (symbol (namespace repl-env)))
                      (mapply (resolve repl-env) compiler-options))
-        stop-ws! (ws/start! queue)]
+        stop-ws! (ws/start! queue)
+        port     (:local-port (meta stop-ws!))]
     (try
       (let [eval (prepl/prepl renv compiler-env compiler-options queue)
             done (keyword (gensym "require-websocket-client-done"))
@@ -247,6 +248,7 @@
 
           (eval '(require 'kaocha.cljs.websocket-client
                           'kaocha.cljs.run))
+          (eval `(kaocha.cljs.websocket-client/connect! ~port))
           (eval done)
 
           (queue-consumer {:queue queue


### PR DESCRIPTION
Solution: Use a port assigned by the operating system

Closes https://github.com/lambdaisland/kaocha-cljs/issues/6.