### PR TITLE
Add Java 16 (and 8) and bump Clojure 1.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,35 +27,33 @@ commands:
           flags: integration
           file: target/coverage/integration*/codecov.json
 
-jobs:
-  java-16-clojure-1_10:
-    executor: clojure/openjdk16
-    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
-  java-15-clojure-1_10:
-    executor: clojure/openjdk15
-    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
-  java-11-clojure-1_10:
+jobs: 
+  java-11-clojure-1_10: 
     executor: clojure/openjdk11
-    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
-
-  # java-9-clojure-1_9:
-  #   executor: clojure/openjdk9
-  #   steps: [{checkout_and_run: {clojure_version: "1.9.0"}}]
-
-   java-8-clojure-1_10:
+    steps: 
+      - 
+        checkout_and_run: 
+          clojure_version: "1.10.3"
+  java-15-clojure-1_10: 
+    executor: clojure/openjdk15
+    steps: 
+      - 
+        checkout_and_run: 
+          clojure_version: "1.10.3"
+  java-8-clojure-1_10: 
     executor: clojure/openjdk8
-    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
-
-  # java-8-clojure-1_9:
-  #   executor: clojure/openjdk8
-  #   steps: [{checkout_and_run: {clojure_version: "1.9.0"}}]
-
-workflows:
-  kaocha_test:
-    jobs:
+    steps: 
+      - 
+        checkout_and_run: 
+          clojure_version: "1.10.3"
+orbs: 
+  clojure: lambdaisland/clojure@0.0.4
+  kaocha: lambdaisland/kaocha@0.0.1
+version: 2.1
+workflows: 
+  kaocha_test: 
+    jobs: 
       - java-16-clojure-1_10
       - java-15-clojure-1_10
       - java-11-clojure-1_10
-      # - java-9-clojure-1_9
       - java-8-clojure-1_10
-      # - java-8-clojure-1_9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,25 @@
-version: 2.1
-
-orbs:
-  kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.4
-
-commands:
-  checkout_and_run:
-    parameters:
-      clojure_version:
+--- 
+commands: 
+  checkout_and_run: 
+    parameters: 
+      clojure_version: 
         type: string
-    steps:
+    steps: 
       - checkout
-      - clojure/with_cache:
-          cache_version: << parameters.clojure_version >>
-          steps:
-            - run: clojure -e '(println (System/getProperty "java.runtime.name") (System/getProperty "java.runtime.version") "\nClojure" (clojure-version))'
-            # - kaocha/execute:
-            #     args: "unit --reporter documentation --plugin cloverage --codecov"
-            #     clojure_version: << parameters.clojure_version >>
-            - kaocha/execute:
+      - 
+        clojure/with_cache: 
+          cache_version: "<< parameters.clojure_version >>"
+          steps: 
+            - 
+              run: "clojure -e '(println (System/getProperty \"java.runtime.name\") (System/getProperty \"java.runtime.version\") \"\\nClojure\" (clojure-version))'"
+            - 
+              kaocha/execute: 
                 args: "integration --reporter documentation --plugin cloverage --codecov"
-                clojure_version: << parameters.clojure_version >>
-      # - kaocha/upload_codecov:
-      #     flags: unit
-      - kaocha/upload_codecov:
-          flags: integration
+                clojure_version: "<< parameters.clojure_version >>"
+      - 
+        kaocha/upload_codecov: 
           file: target/coverage/integration*/codecov.json
-
+          flags: integration
 jobs: 
   java-11-clojure-1_10: 
     executor: clojure/openjdk11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.2
+  clojure: lambdaisland/clojure@0.0.4
 
 commands:
   checkout_and_run:
@@ -28,20 +28,23 @@ commands:
           file: target/coverage/integration*/codecov.json
 
 jobs:
+  java-16-clojure-1_10:
+    executor: clojure/openjdk16
+    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
   java-15-clojure-1_10:
     executor: clojure/openjdk15
-    steps: [{checkout_and_run: {clojure_version: "1.10.1"}}]
+    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
   java-11-clojure-1_10:
     executor: clojure/openjdk11
-    steps: [{checkout_and_run: {clojure_version: "1.10.1"}}]
+    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
 
   # java-9-clojure-1_9:
   #   executor: clojure/openjdk9
   #   steps: [{checkout_and_run: {clojure_version: "1.9.0"}}]
 
-  # java-8-clojure-1_10:
-  #   executor: clojure/openjdk8
-  #   steps: [{checkout_and_run: {clojure_version: "1.10.0-RC3"}}]
+   java-8-clojure-1_10:
+    executor: clojure/openjdk8
+    steps: [{checkout_and_run: {clojure_version: "1.10.3}}]
 
   # java-8-clojure-1_9:
   #   executor: clojure/openjdk8
@@ -50,8 +53,9 @@ jobs:
 workflows:
   kaocha_test:
     jobs:
+      - java-16-clojure-1_10
       - java-15-clojure-1_10
       - java-11-clojure-1_10
       # - java-9-clojure-1_9
-      # - java-8-clojure-1_10
+      - java-8-clojure-1_10
       # - java-8-clojure-1_9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
 
    java-8-clojure-1_10:
     executor: clojure/openjdk8
-    steps: [{checkout_and_run: {clojure_version: "1.10.3}}]
+    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
 
   # java-8-clojure-1_9:
   #   executor: clojure/openjdk8


### PR DESCRIPTION
Update CircleCI to include the latest Java release and a newer version of Clojure 1.10
