### PR TITLE
Fix Windows tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - run:
           command: |
             $ErrorActionPreference = "Stop"
-            clojure "-J-Dline.separator=`n" -A:dev:test -m kaocha.runner unit  2>&1
+            clojure "-J-Dline.separator=`n" -A:dev:test -m kaocha.runner integration  2>&1
             exit $lastexitcode
           shell: powershell.exe
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
   clojure: lambdaisland/clojure@0.0.2
+  win: circleci/windows@2.2.0
 
 commands:
   checkout_and_run:
@@ -34,6 +35,26 @@ jobs:
   java-11-clojure-1_10:
     executor: clojure/openjdk11
     steps: [{checkout_and_run: {clojure_version: "1.10.1"}}]
+  windows-test:
+    executor:
+      name: win/default
+    steps:
+      - checkout
+      - run:
+          command: $(echo hello | Out-Host; $?) -and $(echo world | Out-Host; $?)
+          shell: powershell.exe
+      - run:
+          command: Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://download.clojure.org/install/win-install-1.10.3.839.ps1')
+          shell: powershell.exe
+      - run:
+          command: clojure -e "(println (System/getProperty \`"java.runtime.name\`") (System/getProperty \`"java.runtime.version\`") \`"`nClojure\`" (clojure-version))"
+          shell: powershell.exe
+      - run:
+          command: |
+            $ErrorActionPreference = "Stop"
+            clojure "-J-Dline.separator=`n" -A:dev:test -m kaocha.runner unit  2>&1
+            exit $lastexitcode
+          shell: powershell.exe
 
   # java-9-clojure-1_9:
   #   executor: clojure/openjdk9
@@ -55,3 +76,4 @@ workflows:
       # - java-9-clojure-1_9
       # - java-8-clojure-1_10
       # - java-8-clojure-1_9
+      - windows-test

--- a/src/kaocha/cljs/platform.clj
+++ b/src/kaocha/cljs/platform.clj
@@ -1,0 +1,13 @@
+(ns kaocha.cljs.platform "Utility functions for specific platforms.")
+
+
+(defn on-windows? 
+  "Return whether we're running on Windows."
+  []
+  (re-find #"Windows" (System/getProperty "os.name")))
+
+
+(defn on-posix?
+  "Return whether we're running on a Posix system."
+  []
+  (re-find #"(?ix)(MacOS|Linux)" (System/getProperty "os.name")))

--- a/test/step_definitions/kaocha_integration.clj
+++ b/test/step_definitions/kaocha_integration.clj
@@ -111,7 +111,9 @@
       (spit (str runner)
             (str/join " "
                       (cond-> ["clojure"
+                               (if (platform/on-windows?) 
                                "\"-J-Dline.separator=`\"`n`\"\""
+                                "-J-Dline.separator=$'\n'")
                                "-m" "kaocha.runner"]
                         (codecov?)
                         (into ["--plugin" "cloverage"

--- a/test/step_definitions/kaocha_integration.clj
+++ b/test/step_definitions/kaocha_integration.clj
@@ -111,6 +111,7 @@
       (spit (str runner)
             (str/join " "
                       (cond-> ["clojure"
+                               "\"-J-Dline.separator=`\"`n`\"\""
                                "-m" "kaocha.runner"]
                         (codecov?)
                         (into ["--plugin" "cloverage"
@@ -155,11 +156,12 @@
           (run! #(fs/copy % (io/file (join target (.getName %)))) (fs/glob cache "*"))))
 
     (let [result (if (platform/on-windows?) 
-                   (shell/sh "powershell.exe" "-Command" (format "\"&{%s; [Environment]::Exit(1)}" args))
+                   (shell/sh "powershell.exe"  "-Command" (format "\"&{%s; [Environment]::Exit(1)}" args) :dir dir)
                    (apply shell/sh (conj (shellwords args)
                                                                   :dir dir)) 
                      )  ]
       ;; By default these are hidden unless the test fails
+      ;(println (slurp "bin/kaocha.ps1"))
       (when (seq (:out result))
         (println (str dir) "$" args)
         (println (str (output/colored :underline "stdout") ":\n" (:out result))))

--- a/test/step_definitions/kaocha_integration.clj
+++ b/test/step_definitions/kaocha_integration.clj
@@ -118,7 +118,10 @@
                         :always
                         (conj "\"$@\""))))
       (write-deps-edn deps-edn)
-      (Files/setPosixFilePermissions runner (PosixFilePermissions/fromString "rwxr--r--"));
+      (doto (io/file runner) ;"rwxr--r--"
+          (.setReadable true true) ; make it readable for everyone
+          (.setWritable true false) ; make it writeable only for the owner
+          (.setExecutable true false))
       (assoc m
              :dir dir
              :test-dir test-dir


### PR DESCRIPTION
Start of fixes to allow kaocha-cljs tests to work correctly on Windows:

- [ ] Fix remaining tests (will fill in when I'm on Windows)
- [ ] Add Windows executor to CircleCI
- [ ] Figure out why tests are much slower and timing out now. (this is why it's WIP now)

This is a new version of #40, which Github helpfully closed automatically when Arne deleted `master`.