### PR TITLE
Remove references to now non-existent var in humane-print

### DIFF
--- a/src/kaocha/cljs/websocket_client.cljs
+++ b/src/kaocha/cljs/websocket_client.cljs
@@ -76,8 +76,7 @@
 
 (defn pretty-print-failure [m]
   (let [buffer (StringBuffer.)]
-    (binding [humane-print/*sb* buffer
-              *out*             (pp/get-pretty-writer (StringBufferWriter. buffer))]
+    (binding [*out* (pp/get-pretty-writer (StringBufferWriter. buffer))]
       (let [{:keys [type expected actual diffs message] :as event}
             (humane-print/convert-event m)
             print-expected (fn [actual]
@@ -97,7 +96,7 @@
             (when b
               (pp/pprint b *out*)))
           (print-expected actual)))
-      (str humane-print/*sb*))))
+      (str buffer))))
 
 (defn cljs-test-msg [m]
   ;; This is terrible all around, but ClojureScript's logic for detecting


### PR DESCRIPTION
<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
# The Problem
When running inside docker, warnings about an undeclared var are displayed:

![Screen Shot 2022-02-25 at 4 12 10 PM](https://user-images.githubusercontent.com/8422330/155819646-229b04e6-26ca-4e2e-8488-38df8da0f35b.png)

I don't know why it seems to only be happening in docker and it does not seem to be breaking anything, but the warnings seem to have a point. The var `humane-print/*sb*` was replaced by a private var `sb` in the `0.10.0` release of `humane-test-output`: https://github.com/pjstadig/humane-test-output/commit/f01d7eec9d0ebf774a2956d8322556fcb8253c03

# The Fix
Remove all references to `humane-print/*sb*`

Given that new var, `humane-print/sb`, is now private, it probably shouldn't be accessed.  Additionally, since `humane-print/clean` and `humane-print/with-pretty-writer` are the only functions that references that var now and this uses neither, this change should not effect `kaocha-cljs` (except for the warnings).


