### PR TITLE
Fix npm-deps not quite working

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,33 @@ bin/kaocha unit-cljs
   the REPL is able to connect. If this is the case you can set this to `true`.
   Defaults to `false`.
 
+## Configuration for npm dependency
+
+When using kaocha-cljs with `:npm-deps`, you need to:
+
+- enable precompilation
+- make sure `:main`, `:install-deps`, `:npm-deps` are all set in the compiler options
+
+For example, if we want to compile left-pad npm library as npm dependency, the 
+`tests.edn` is like:
+
+```
+#kaocha/v1
+    {:bindings        {kaocha.type.cljs/*debug* true}
+     :capture-output? false
+     :tests           [{:id                    :unit-cljs
+                        :type                  :kaocha.type/cljs
+                        :cljs/precompile?      true
+                        :cljs/compiler-options {:main         npm_deps.main
+                                                :verbose      true
+                                                :install-deps true
+                                                :npm-deps     {:left-pad "1.1.3"}}
+                        :source-paths          ["src"]
+                        :test-paths            ["test"]}]}
+```
+Note: We use the compiler options twice `(if :cljs/precompile? is true)`: once to do the 
+      precompilation, and another once to start a REPL to communicate with.
+
 ## Known issues
 
 - The `:test-paths` do not get automatically added to the classpath (at least not

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ When using kaocha-cljs with `:npm-deps`, you need to:
 - enable precompilation
 - make sure `:main`, `:install-deps`, `:npm-deps` are all set in the compiler options
 
-For example, if we want to compile left-pad npm library as npm dependency, the 
-`tests.edn` is like:
+For example, if we want to compile the left-pad npm library as an npm dependency, the 
+`tests.edn` should look like:
 
 ```
 #kaocha/v1

--- a/src/kaocha/type/cljs.clj
+++ b/src/kaocha/type/cljs.clj
@@ -83,10 +83,10 @@
                              (let [ns-sym (file->ns-name ns-file)]
                                (when (load/ns-match? ns-patterns ns-sym)
                                  (ns-testable ns-sym ns-file))))
-                           test-files) ]
+                           test-files)]
     (if (version-check/meets-minimum-cljs-version 1 10)
       (assoc testable
-             :cljs/compiler-options copts
+             :cljs/compiler-options (dissoc copts :main)
              :cljs/repl-env repl-env
              :cljs/timeout timeout
              :cljs/compiler-env cenv
@@ -98,7 +98,7 @@
                  (fn []
                    (testable/load-testables testables)))))
       (assoc testable :kaocha.testable/load-error
-             (ex-info "ClojureScript version too low" {:expected ">=1.10"  :got (cljs.util/clojurescript-version) })))))
+             (ex-info "ClojureScript version too low" {:expected ">=1.10"  :got (cljs.util/clojurescript-version)})))))
 
 (defmethod testable/-load ::ns [testable]
   (let [ns-name (::ns testable)
@@ -256,9 +256,9 @@
                           'kaocha.cljs.run))
 
           (eval `((~'fn ~'wait-for-websocket-client []
-                    (if (~'exists? kaocha.cljs.websocket-client)
-                      (kaocha.cljs.websocket-client/connect! ~port)
-                      (js/setTimeout ~'wait-for-websocket-client 50)))))
+                        (if (~'exists? kaocha.cljs.websocket-client)
+                          (kaocha.cljs.websocket-client/connect! ~port)
+                          (js/setTimeout ~'wait-for-websocket-client 50)))))
           (eval done)
 
           (queue-consumer {:queue queue
@@ -333,9 +333,9 @@
   (eval `(kaocha.cljs.run/run-once-fixtures
           ~ns ~before-or-after
           (~'fn []
-           (kaocha.cljs.websocket-client/send!
-            {:type ::fixture-loaded
-             :fixture ['~ns ~before-or-after]}))))
+                (kaocha.cljs.websocket-client/send!
+                 {:type ::fixture-loaded
+                  :fixture ['~ns ~before-or-after]}))))
 
   (queue-consumer {:queue queue
                    :timeout timeout
@@ -351,9 +351,9 @@
         done (keyword (gensym "require-ns-done"))]
     (eval `(~'require '~ns))
     (eval `((~'fn ~'wait-for-symbol []
-             (if (~'exists? ~ns)
-               (kaocha.cljs.websocket-client/send! {:type :cljs/exists :symbol '~ns})
-               (js/setTimeout ~'wait-for-symbol 50)))))
+                  (if (~'exists? ~ns)
+                    (kaocha.cljs.websocket-client/send! {:type :cljs/exists :symbol '~ns})
+                    (js/setTimeout ~'wait-for-symbol 50)))))
     (eval done)
 
     (queue-consumer {:queue queue
@@ -469,11 +469,8 @@
                                           :kaocha/test-paths    ["test/cljs"]
                                           :kaocha/ns-patterns   [".*-test$"]
                                           :cljs/timeout 50000
-                                          :cljs/repl-env 'cljs.repl.browser/repl-env
-                                          }]
+                                          :cljs/repl-env 'cljs.repl.browser/repl-env}]
                           :kaocha.plugin.capture-output/capture-output? false
                           :kaocha/reporter ['kaocha.report/documentation]})
 
-  (require 'kaocha.type.var)
-
-  )
+  (require 'kaocha.type.var))


### PR DESCRIPTION
For the bug/issues pointed out [here](https://github.com/markdingram/npm-deps-kaocha). #25 

It all works fine if a change is made to kaocha-cljs to `(dissoc copts :main)` prior to starting the REPL.

Just implemented it.

```
(dissoc copts :main)
```

You can verify the results by using this [repo](https://github.com/markdingram/npm-deps-kaocha).
Remember that when you link kaocha-cljs to the new version, you should also change the kaocha to the newer version, otherwise it will not run. 